### PR TITLE
Add JSON example

### DIFF
--- a/examples/local_store_json.rs
+++ b/examples/local_store_json.rs
@@ -1,0 +1,26 @@
+// Copyright 2025 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use lake_pulse::{Analyzer, StorageConfig};
+
+#[tokio::main]
+async fn main() {
+    let storage_config = StorageConfig::local().with_option("path", "./examples/data");
+    let analyzer = Analyzer::builder(storage_config).build().await.unwrap();
+
+    // Generate report
+    let report = analyzer.analyze("delta_dataset").await.unwrap();
+
+    // Print pretty report
+    println!("{}", report.to_json(true).unwrap());
+}


### PR DESCRIPTION
Add JSON output example on local Delta Lake table

## Description

Add JSON output example on local Delta Lake table that can be run with `cargo run --example local_store_json`

## Related Issue

N/A

## Motivation and Context

Better understanding of the library functionality

## How Has This Been Tested?

Tested running the example with `cargo run --example local_store_json`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
