### PR TITLE
deps(deps): Update object_store requirement from 0.12 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ deltalake-aws = "0.12"
 iceberg = { version = "0.7.0", features = ["storage-all"] }
 lance = { version = "1.0", optional = true }
 
-object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
+object_store = { version = "0.13", features = ["aws", "azure", "gcp"] }
 url = "2.5"
 async-trait = "0.1"
 thiserror = "2.0"

--- a/src/reader/hudi/reader.rs
+++ b/src/reader/hudi/reader.rs
@@ -16,7 +16,7 @@ use super::metrics::{
 };
 use chrono::NaiveDateTime;
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::error::Error;

--- a/src/storage/object_store.rs
+++ b/src/storage/object_store.rs
@@ -20,7 +20,7 @@ use bytes::Bytes;
 use futures::stream::StreamExt;
 use object_store::{
     aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
-    local::LocalFileSystem, ClientOptions, ObjectStore, RetryConfig,
+    local::LocalFileSystem, ClientOptions, ObjectStore, ObjectStoreExt, RetryConfig,
 };
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};


### PR DESCRIPTION
Update object_store requirement from 0.12 to 0.13

## Description

Update object_store requirement from 0.12 to 0.13

## Related Issue

N/A

## Motivation and Context

Keep up the quality of the projects

## How Has This Been Tested?

UTs, ITs, Examples, Doc tests, etc.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
