### PR TITLE
ci: Don’t trigger Release PR Status for closer PRs

### DIFF
--- a/.github/workflows/release-pr-status.yml
+++ b/.github/workflows/release-pr-status.yml
@@ -59,7 +59,9 @@ jobs:
     # For 'labeled' events: require BOTH the branch prefix AND the release label
     # For other events (opened, synchronize, reopened): only check branch prefix
     # This handles the race condition where release-plz adds the label AFTER pushing
+    # Also ensure the PR is still open (not merged or closed)
     if: |
+      github.event.pull_request.state == 'open' &&
       startsWith(github.head_ref, 'release-plz-') &&
       (github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
Don’t trigger Release PR Status for closer PRs

## Description

Don’t trigger Release PR Status for closer PRs

## Related Issue

Don’t trigger Release PR Status for closer PRs

## Motivation and Context

Better CI/CD feedback

## How Has This Been Tested?

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
