### PR TITLE
feat!: Add HDFS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bytes = "1.0"
 chrono = "0.4"
 log = "0.4.28"
 parquet = "57.1"
+hdfs-native-object-store = "0.16"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ![Lake Pulse Logo](lake-pulse-logo-new.svg)
 
-A Rust library for analyzing data lake table health — *checking the pulse* — across multiple formats (Delta Lake, Apache Iceberg, Apache Hudi, Lance) and storage providers (AWS S3, Azure Data Lake, GCS, Local).
+A Rust library for analyzing data lake table health — *checking the pulse* — across multiple formats (Delta Lake, Apache Iceberg, Apache Hudi, Lance) and storage providers (AWS S3, Azure Data Lake, GCS, HDFS, Local).
 
 ## Supported Formats
 
@@ -138,6 +138,18 @@ Common options for GCP (see [object_store GCP documentation](https://docs.rs/obj
 - `bucket` - GCS bucket name
 - `service_account_key` - Path to service account JSON key file
 
+### HDFS Configuration Options
+
+HDFS support is provided via the [`hdfs-native-object-store`](https://docs.rs/hdfs-native-object-store/) crate:
+- `url` - HDFS namenode URL (e.g., "hdfs://namenode:8020")
+
+```rust
+let storage_config = StorageConfig::hdfs()
+    .with_option("url", "hdfs://namenode:8020");
+let analyzer = Analyzer::builder(storage_config).build().await.unwrap();
+let report = analyzer.analyze("/path/to/table").await.unwrap();
+```
+
 ### Local Filesystem
 
 ```rust
@@ -151,6 +163,7 @@ let report = analyzer.analyze("/path/to/table").await.unwrap();
 See the [`examples/`](examples/) directory for more detailed usage examples:
 - `s3_store.rs` - AWS S3 example
 - `adl_store.rs` - Azure Data Lake example
+- `hdfs_store.rs` - HDFS example
 - `local_store.rs` - Local filesystem example
 - `local_store_iceberg.rs` - Iceberg table example
 - `local_store_hudi.rs` - Hudi table example *(requires `hudi` feature)*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ![Lake Pulse Logo](../lake-pulse-logo-new.svg)
 
-A Rust library for analyzing data lake table health — *checking the pulse* — across multiple formats (Delta Lake, Apache Iceberg, Apache Hudi, Lance) and storage providers (AWS S3, Azure Data Lake, GCS, Local).
+A Rust library for analyzing data lake table health — *checking the pulse* — across multiple formats (Delta Lake, Apache Iceberg, Apache Hudi, Lance) and storage providers (AWS S3, Azure Data Lake, GCS, HDFS, Local).
 
 # Documentation
 
@@ -28,10 +28,12 @@ See the [examples](../examples/) directory for more detailed usage examples.
 
 ## Cloud Storage Documentation
 
-For detailed information on configuration options, refer to the `object_store` crate documentation:
+For detailed information on configuration options, refer to the `object_store` and 
+`hdfs-native-object-store` crates documentation:
 - [AWS S3 Configuration](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)
 - [Azure Configuration](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)
 - [GCP Configuration](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
+- [HDFS Configuration](https://docs.rs/hdfs-native-object-store/latest/hdfs_native_object_store/)
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This is a folder where some examples are provided to understand the use of the l
 Some tables need to be created, some are easy to create, some are not. The `data/README.md` file
 contains instructions on how to create the tables.
 
-For Azure ADLS and AWS S3 storage examples you will need to provide the needed credentials.
+For Azure ADLS, AWS S3, and HDFS storage examples you will need to provide the needed credentials or access to the respective storage systems.
 
 ## Run the Examples
 

--- a/examples/hdfs_store.rs
+++ b/examples/hdfs_store.rs
@@ -1,0 +1,26 @@
+// Copyright 2025 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+//
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use lake_pulse::{Analyzer, StorageConfig};
+
+#[tokio::main]
+async fn main() {
+    let storage_config = StorageConfig::hdfs().with_option("url", "hdfs://namenode:8020");
+    let analyzer = Analyzer::builder(storage_config).build().await.unwrap();
+
+    // Generate report
+    let report = analyzer.analyze("/path/to/table").await.unwrap();
+
+    // Print pretty report
+    println!("{}", report);
+}


### PR DESCRIPTION
Add HDFS support

## Description

This PR adds support for HDFS by using the `hdfs-native-object-store` crate.

## Related Issue

Missing support for HSDF.

## Motivation and Context

Lake Pulse didn't had HDFS support as `object_store` crate supports only cloud storages.

## How Has This Been Tested?

UTs, examples, docs, etc

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
