### PR TITLE
fix: Get away from deprecated funcs for `object_store`

### DIFF
--- a/src/reader/hudi/reader.rs
+++ b/src/reader/hudi/reader.rs
@@ -370,7 +370,7 @@ impl HudiReader {
         let store = Arc::new(store);
 
         // Read hoodie.properties
-        let props_path = base_path.child(".hoodie").child("hoodie.properties");
+        let props_path = base_path.clone().join(".hoodie").join("hoodie.properties");
         let props_content = match store.get(&props_path).await {
             Ok(result) => {
                 let bytes = result.bytes().await?;
@@ -400,7 +400,7 @@ impl HudiReader {
         info!("Extracting metrics from Hudi table");
 
         // List timeline files
-        let hoodie_path = self.base_path.child(".hoodie");
+        let hoodie_path = self.base_path.clone().join(".hoodie");
         let timeline_files = self.list_timeline_files(&hoodie_path).await?;
 
         // Parse timeline and extract metrics

--- a/src/reader/paimon/reader.rs
+++ b/src/reader/paimon/reader.rs
@@ -144,7 +144,7 @@ impl PaimonReader {
         let store = Arc::new(store);
 
         // Read the LATEST file to get current snapshot ID
-        let latest_path = base_path.child("snapshot").child("LATEST");
+        let latest_path = base_path.clone().join("snapshot").join("LATEST");
         let current_snapshot_id = match store.get(&latest_path).await {
             Ok(result) => {
                 let bytes = result.bytes().await?;
@@ -159,8 +159,9 @@ impl PaimonReader {
 
         // Read current snapshot
         let snapshot_path = base_path
-            .child("snapshot")
-            .child(format!("snapshot-{}", current_snapshot_id));
+            .clone()
+            .join("snapshot")
+            .join(format!("snapshot-{}", current_snapshot_id));
         let current_snapshot = match store.get(&snapshot_path).await {
             Ok(result) => {
                 let bytes = result.bytes().await?;
@@ -181,8 +182,9 @@ impl PaimonReader {
         // Read current schema
         let schema_id = current_snapshot.as_ref().map(|s| s.schema_id).unwrap_or(0);
         let schema_path = base_path
-            .child("schema")
-            .child(format!("schema-{}", schema_id));
+            .clone()
+            .join("schema")
+            .join(format!("schema-{}", schema_id));
         let current_schema = match store.get(&schema_path).await {
             Ok(result) => {
                 let bytes = result.bytes().await?;
@@ -242,7 +244,7 @@ impl PaimonReader {
     async fn extract_snapshot_metrics(
         &self,
     ) -> Result<SnapshotMetrics, Box<dyn Error + Send + Sync>> {
-        let snapshot_dir = self.base_path.child("snapshot");
+        let snapshot_dir = self.base_path.clone().join("snapshot");
         let mut total_snapshots = 0usize;
         let mut earliest_snapshot_id: Option<i64> = None;
 
@@ -286,7 +288,7 @@ impl PaimonReader {
     }
 
     async fn extract_schema_metrics(&self) -> Result<SchemaMetrics, Box<dyn Error + Send + Sync>> {
-        let schema_dir = self.base_path.child("schema");
+        let schema_dir = self.base_path.clone().join("schema");
         let mut total_schema_versions = 0usize;
 
         let mut stream = self.store.list(Some(&schema_dir));
@@ -322,7 +324,7 @@ impl PaimonReader {
         let mut total_manifest_size_bytes = 0u64;
 
         // Count manifest files by listing
-        let manifest_dir = self.base_path.child("manifest");
+        let manifest_dir = self.base_path.clone().join("manifest");
         let mut stream = self.store.list(Some(&manifest_dir));
         while let Some(item) = stream.next().await {
             if let Ok(meta) = item {
@@ -484,7 +486,11 @@ impl PaimonReader {
         &self,
         manifest_list_name: &str,
     ) -> Result<Vec<ManifestListEntry>, Box<dyn Error + Send + Sync>> {
-        let manifest_list_path = self.base_path.child("manifest").child(manifest_list_name);
+        let manifest_list_path = self
+            .base_path
+            .clone()
+            .join("manifest")
+            .join(manifest_list_name);
         debug!("Parsing manifest-list: {}", manifest_list_path);
 
         let result = self.store.get(&manifest_list_path).await?;
@@ -515,7 +521,7 @@ impl PaimonReader {
         &self,
         manifest_name: &str,
     ) -> Result<Vec<ManifestEntry>, Box<dyn Error + Send + Sync>> {
-        let manifest_path = self.base_path.child("manifest").child(manifest_name);
+        let manifest_path = self.base_path.clone().join("manifest").join(manifest_name);
         debug!("Parsing manifest: {}", manifest_path);
 
         let result = self.store.get(&manifest_path).await?;


### PR DESCRIPTION
Get away from deprecated funcs for `object_strore`

## Description

Get away from deprecated funcs for `object_strore`

## Related Issue

N/A

## Motivation and Context

The build will fail when `RUSTFLAGS="-D warnings"` is used.

## How Has This Been Tested?

UTs, ITs

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
